### PR TITLE
Fix: deleteAll does not delete anything in the generated repository implementation classes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Fixed
+
+- deleteAll does not delete anything in the generated repository implementation classes
+
 == [1.0.2] - 2023-10-01
 
 === Added

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -112,7 +112,7 @@ class PersonCrudRepositoryTest {
     public void shouldDeleteAllEntities() {
         personRepository.deleteAll();
 
-        verify(template, times(1)).delete(eq(Person.class));
+        verify(template, times(1)).deleteAll(eq(Person.class));
     }
 
     @Test

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -116,7 +116,7 @@ class PersonRepositoryTest {
     public void shouldDeleteAllEntities() {
         personRepository.deleteAll();
 
-        verify(template, times(1)).delete(eq(Person.class));
+        verify(template, times(1)).deleteAll(eq(Person.class));
     }
 
     @Test

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -115,7 +115,7 @@ class PersonCrudRepositoryTest {
     public void shouldDeleteAllEntities() {
         personRepository.deleteAll();
 
-        verify(template, times(1)).delete(eq(Person.class));
+        verify(template, times(1)).deleteAll(eq(Person.class));
     }
 
     @Test

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -118,7 +118,7 @@ class PersonRepositoryTest {
     public void shouldDeleteAllEntities() {
         personRepository.deleteAll();
 
-        verify(template, times(1)).delete(eq(Person.class));
+        verify(template, times(1)).deleteAll(eq(Person.class));
     }
 
     @Test

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryLiteGraphTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryLiteGraphTest.java
@@ -99,7 +99,7 @@ public class PersonCrudRepositoryLiteGraphTest {
     public void shouldDeleteAllEntities() {
         repository.deleteAll();
 
-        verify(template).delete(eq(Person.class));
+        verify(template).deleteAll(eq(Person.class));
     }
 
     @Test

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryLiteGraphTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryLiteGraphTest.java
@@ -100,7 +100,7 @@ public class PersonRepositoryLiteGraphTest {
     public void shouldDeleteAllEntities() {
         repository.deleteAll();
 
-        verify(template).delete(eq(Person.class));
+        verify(template).deleteAll(eq(Person.class));
     }
 
     @Test

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_column.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_column.mustache
@@ -123,7 +123,7 @@ public class {{className}} implements {{repository}} {
 
     @Override
     public void deleteAll() {
-        getTemplate().delete(getEntityClass());
+        getTemplate().deleteAll(getEntityClass());
     }
 
     @Override

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_document.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_document.mustache
@@ -121,7 +121,7 @@ public class {{className}} implements {{repository}} {
 
     @Override
     public void deleteAll() {
-       getTemplate().delete(getEntityClass());
+       getTemplate().deleteAll(getEntityClass());
     }
 
     @Override

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_graph.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_graph.mustache
@@ -117,7 +117,7 @@ public class {{className}} implements {{repository}} {
 
     @Override
     public void deleteAll() {
-       getTemplate().delete(getEntityClass());
+       getTemplate().deleteAll(getEntityClass());
     }
 
     @Override


### PR DESCRIPTION
## Changes

- Fixed the mustache templates to call `getTemplate().deleteAll()` method instead of `getTemplate().delete()`
