### PR TITLE
ci: update deprecated actions

### DIFF
--- a/.github/workflows/java-17.yml
+++ b/.github/workflows/java-17.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 17

--- a/.github/workflows/java-21.yml
+++ b/.github/workflows/java-21.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21


### PR DESCRIPTION
##Changes

Bump up the actions that use Node.js 20 runtime (For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/):

- actions/checkout@v3 to v4;
- actions/setup-java@v3 to v4;