### PR TITLE
Upgrade to jakarta data 1.0.0 m3

### DIFF
--- a/.github/workflows/java-17.yml
+++ b/.github/workflows/java-17.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 17

--- a/.github/workflows/java-21.yml
+++ b/.github/workflows/java-21.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Added
+
+- Upgrade API to Jakarta Data 1.0.0-M3
+
 == [1.1.0] - 2023-02-05
 
 === Added

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -15,10 +15,10 @@
 package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
-import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
@@ -28,11 +28,11 @@ import jakarta.data.repository.Update;
 import java.util.List;
 
 @Repository
-public interface PersonRepository extends PageableRepository<Person, Long> {
+public interface PersonRepository extends BasicRepository<Person, Long> {
 
     List<Person> findByName(String name);
 
-    Page<Person> findByName(String name, Pageable pageable);
+    Page<Person> findByName(String name, PageRequest<Person> pageRequest);
 
     @Query("select * from Person where name = @name")
     List<Person> query(@Param("name") String name);

--- a/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-column-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -16,7 +16,6 @@ package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
-import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Param;
@@ -24,11 +23,12 @@ import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
+import org.eclipse.jnosql.mapping.NoSQLRepository;
 
 import java.util.List;
 
 @Repository
-public interface PersonRepository extends BasicRepository<Person, Long> {
+public interface PersonRepository extends NoSQLRepository<Person, Long> {
 
     List<Person> findByName(String name);
 

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -109,13 +109,6 @@ class PersonCrudRepositoryTest {
     }
 
     @Test
-    void shouldDeleteAllEntities() {
-        personRepository.deleteAll();
-
-        verify(template, times(1)).deleteAll(eq(Person.class));
-    }
-
-    @Test
     void shouldFindAllEntitiesByIds() {
         List<Long> ids = Arrays.asList(123L, 456L);
         Person person1 = new Person();
@@ -134,7 +127,7 @@ class PersonCrudRepositoryTest {
         long expectedCount = 5L;
         when(template.count(eq(Person.class))).thenReturn(expectedCount);
 
-        long count = personRepository.count();
+        long count = personRepository.countBy();
 
         assertEquals(expectedCount, count);
         verify(template, times(1)).count(eq(Person.class));

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -125,6 +125,12 @@ class PersonRepositoryTest {
         verify(template, times(1)).delete(eq(Person.class),eq(person.getId()));
     }
 
+    @Test
+    void shouldDeleteAllEntities() {
+        personRepository.deleteAll();
+
+        verify(template, times(1)).deleteAll(eq(Person.class));
+    }
 
     @Test
     void shouldUpdate(){

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -14,10 +14,9 @@
  */
 package org.eclipse.jnosql.lite.mapping.entities;
 
-import jakarta.data.Limit;
-import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
 import jakarta.data.Sort;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
 import jakarta.nosql.PreparedStatement;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
@@ -42,8 +41,19 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -115,12 +125,6 @@ class PersonRepositoryTest {
         verify(template, times(1)).delete(eq(Person.class),eq(person.getId()));
     }
 
-    @Test
-    void shouldDeleteAllEntities() {
-        personRepository.deleteAll();
-
-        verify(template, times(1)).deleteAll(eq(Person.class));
-    }
 
     @Test
     void shouldUpdate(){
@@ -166,7 +170,7 @@ class PersonRepositoryTest {
         long expectedCount = 5L;
         when(template.count(eq(Person.class))).thenReturn(expectedCount);
 
-        long count = personRepository.count();
+        long count = personRepository.countBy();
 
         assertEquals(expectedCount, count);
         verify(template, times(1)).count(eq(Person.class));
@@ -196,8 +200,8 @@ class PersonRepositoryTest {
 
 
     @Test
-    void shouldFindAllEntitiesWithPageable() {
-        Pageable pageable = mock(Pageable.class);
+    void shouldFindAllEntitiesWithPageRequest() {
+        PageRequest pageable = mock(PageRequest.class);
         when(template.select(any(ColumnQuery.class))).thenReturn( Stream.of(new Person(), new Person()));
 
         Page<Person> page = personRepository.findAll(pageable);
@@ -208,7 +212,7 @@ class PersonRepositoryTest {
     }
 
     @Test
-    void shouldThrowExceptionIfPageableIsNull() {
+    void shouldThrowExceptionIfPageRequestIsNull() {
         assertThrows(NullPointerException.class, () -> personRepository.findAll(null));
     }
 
@@ -286,9 +290,9 @@ class PersonRepositoryTest {
 
 
     @Test
-    void shouldFindPageable(){
+    void shouldFindPageRequest(){
         when(template.select(any(ColumnQuery.class))).thenReturn( Stream.of(new Person(), new Person()));
-        Pageable pageable = Pageable.ofPage(10).sortBy(Sort.asc("name"));
+        PageRequest pageable = PageRequest.ofPage(10).sortBy(Sort.asc("name"));
         Page<Person> result = this.personRepository.findByName("Ada", pageable);
         ArgumentCaptor<ColumnQuery> captor = ArgumentCaptor.forClass(ColumnQuery.class);
         assertThat(result).isNotEmpty().hasSize(2);

--- a/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-column-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -207,10 +207,10 @@ class PersonRepositoryTest {
 
     @Test
     void shouldFindAllEntitiesWithPageRequest() {
-        PageRequest pageable = mock(PageRequest.class);
+        PageRequest pageRequest = mock(PageRequest.class);
         when(template.select(any(ColumnQuery.class))).thenReturn( Stream.of(new Person(), new Person()));
 
-        Page<Person> page = personRepository.findAll(pageable);
+        Page<Person> page = personRepository.findAll(pageRequest);
 
         assertNotNull(page);
         assertEquals(List.of(new Person(), new Person()), page.content());
@@ -298,8 +298,8 @@ class PersonRepositoryTest {
     @Test
     void shouldFindPageRequest(){
         when(template.select(any(ColumnQuery.class))).thenReturn( Stream.of(new Person(), new Person()));
-        PageRequest pageable = PageRequest.ofPage(10).sortBy(Sort.asc("name"));
-        Page<Person> result = this.personRepository.findByName("Ada", pageable);
+        PageRequest pageRequest = PageRequest.ofPage(10).sortBy(Sort.asc("name"));
+        Page<Person> result = this.personRepository.findByName("Ada", pageRequest);
         ArgumentCaptor<ColumnQuery> captor = ArgumentCaptor.forClass(ColumnQuery.class);
         assertThat(result).isNotEmpty().hasSize(2);
         verify(template).select(captor.capture());

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -15,10 +15,10 @@
 package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
-import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
@@ -28,13 +28,13 @@ import jakarta.data.repository.Update;
 import java.util.List;
 
 @Repository
-public interface PersonRepository extends PageableRepository<Person, Long> {
+public interface PersonRepository extends BasicRepository<Person, Long> {
 
     List<Person> findByName(String name);
 
     List<Person> findByNameOrderbyId(String name);
 
-    Page<Person> findByName(String name, Pageable pageable);
+    Page<Person> findByName(String name, PageRequest<Person> pageRequest);
 
     @Query("select * from Person where name = @name")
     List<Person> query(@Param("name") String name);

--- a/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-document-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -16,7 +16,6 @@ package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
-import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Param;
@@ -24,11 +23,12 @@ import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
+import org.eclipse.jnosql.mapping.NoSQLRepository;
 
 import java.util.List;
 
 @Repository
-public interface PersonRepository extends BasicRepository<Person, Long> {
+public interface PersonRepository extends NoSQLRepository<Person, Long> {
 
     List<Person> findByName(String name);
 

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryTest.java
@@ -20,9 +20,6 @@ import org.eclipse.jnosql.communication.Condition;
 import org.eclipse.jnosql.communication.document.DocumentCondition;
 import org.eclipse.jnosql.communication.document.DocumentDeleteQuery;
 import org.eclipse.jnosql.communication.document.DocumentQuery;
-import org.eclipse.jnosql.lite.mapping.entities.Person;
-import org.eclipse.jnosql.lite.mapping.entities.PersonCrudRepositoryLiteDocument;
-import org.eclipse.jnosql.lite.mapping.entities.PersonRepositoryLiteDocument;
 import org.eclipse.jnosql.mapping.document.JNoSQLDocumentTemplate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -112,13 +109,6 @@ class PersonCrudRepositoryTest {
     }
 
     @Test
-    void shouldDeleteAllEntities() {
-        personRepository.deleteAll();
-
-        verify(template, times(1)).deleteAll(eq(Person.class));
-    }
-
-    @Test
     void shouldFindAllEntitiesByIds() {
         List<Long> ids = Arrays.asList(123L, 456L);
         Person person1 = new Person();
@@ -137,7 +127,7 @@ class PersonCrudRepositoryTest {
         long expectedCount = 5L;
         when(template.count(eq(Person.class))).thenReturn(expectedCount);
 
-        long count = personRepository.count();
+        long count = personRepository.countBy();
 
         assertEquals(expectedCount, count);
         verify(template, times(1)).count(eq(Person.class));

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -207,10 +207,10 @@ class PersonRepositoryTest {
 
     @Test
     void shouldFindAllEntitiesWithPageRequest() {
-        PageRequest pageable = mock(PageRequest.class);
+        PageRequest pageRequest = mock(PageRequest.class);
         when(template.select(any(DocumentQuery.class))).thenReturn( Stream.of(new Person(), new Person()));
 
-        Page<Person> page = personRepository.findAll(pageable);
+        Page<Person> page = personRepository.findAll(pageRequest);
 
         assertNotNull(page);
         assertEquals(List.of(new Person(), new Person()), page.content());
@@ -299,8 +299,8 @@ class PersonRepositoryTest {
     @Test
     void shouldFindPageRequest(){
         when(template.select(any(DocumentQuery.class))).thenReturn( Stream.of(new Person(), new Person()));
-        PageRequest<Person> pageable = PageRequest.of(Person.class).page(10).sortBy(Sort.asc("name"));
-        Page<Person> result = this.personRepository.findByName("Ada", pageable);
+        PageRequest<Person> pageRequest = PageRequest.of(Person.class).page(10).sortBy(Sort.asc("name"));
+        Page<Person> result = this.personRepository.findByName("Ada", pageRequest);
         ArgumentCaptor<DocumentQuery> captor = ArgumentCaptor.forClass(DocumentQuery.class);
         assertThat(result).isNotEmpty().hasSize(2);
         verify(template).select(captor.capture());

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -126,6 +126,13 @@ class PersonRepositoryTest {
     }
 
     @Test
+    void shouldDeleteAllEntities() {
+        personRepository.deleteAll();
+
+        verify(template, times(1)).deleteAll(eq(Person.class));
+    }
+
+    @Test
     void shouldUpdate(){
         this.personRepository.update(new Person());
         verify(template).update(any(Person.class));

--- a/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
+++ b/jnosql-lite/mapping-lite-document-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryTest.java
@@ -16,7 +16,7 @@ package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.data.Sort;
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
 import jakarta.nosql.PreparedStatement;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
@@ -126,13 +126,6 @@ class PersonRepositoryTest {
     }
 
     @Test
-    void shouldDeleteAllEntities() {
-        personRepository.deleteAll();
-
-        verify(template, times(1)).deleteAll(eq(Person.class));
-    }
-
-    @Test
     void shouldUpdate(){
         this.personRepository.update(new Person());
         verify(template).update(any(Person.class));
@@ -176,7 +169,7 @@ class PersonRepositoryTest {
         long expectedCount = 5L;
         when(template.count(eq(Person.class))).thenReturn(expectedCount);
 
-        long count = personRepository.count();
+        long count = personRepository.countBy();
 
         assertEquals(expectedCount, count);
         verify(template, times(1)).count(eq(Person.class));
@@ -206,8 +199,8 @@ class PersonRepositoryTest {
 
 
     @Test
-    void shouldFindAllEntitiesWithPageable() {
-        Pageable pageable = mock(Pageable.class);
+    void shouldFindAllEntitiesWithPageRequest() {
+        PageRequest pageable = mock(PageRequest.class);
         when(template.select(any(DocumentQuery.class))).thenReturn( Stream.of(new Person(), new Person()));
 
         Page<Person> page = personRepository.findAll(pageable);
@@ -218,7 +211,7 @@ class PersonRepositoryTest {
     }
 
     @Test
-    void shouldThrowExceptionIfPageableIsNull() {
+    void shouldThrowExceptionIfPageRequestIsNull() {
         assertThrows(NullPointerException.class, () -> personRepository.findAll(null));
     }
 
@@ -297,9 +290,9 @@ class PersonRepositoryTest {
     }
 
     @Test
-    void shouldFindPageable(){
+    void shouldFindPageRequest(){
         when(template.select(any(DocumentQuery.class))).thenReturn( Stream.of(new Person(), new Person()));
-        Pageable pageable = Pageable.ofPage(10).sortBy(Sort.asc("name"));
+        PageRequest<Person> pageable = PageRequest.of(Person.class).page(10).sortBy(Sort.asc("name"));
         Page<Person> result = this.personRepository.findByName("Ada", pageable);
         ArgumentCaptor<DocumentQuery> captor = ArgumentCaptor.forClass(DocumentQuery.class);
         assertThat(result).isNotEmpty().hasSize(2);

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -14,9 +14,9 @@
  */
 package org.eclipse.jnosql.lite.mapping.entities;
 
+import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
-import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
@@ -26,7 +26,7 @@ import jakarta.data.repository.Update;
 import java.util.List;
 
 @Repository
-public interface PersonRepository extends PageableRepository<Person, Long> {
+public interface PersonRepository extends BasicRepository<Person, Long> {
 
     List<Person> findByName(String name);
 

--- a/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -14,7 +14,6 @@
  */
 package org.eclipse.jnosql.lite.mapping.entities;
 
-import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Param;
@@ -22,11 +21,12 @@ import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
+import org.eclipse.jnosql.mapping.NoSQLRepository;
 
 import java.util.List;
 
 @Repository
-public interface PersonRepository extends BasicRepository<Person, Long> {
+public interface PersonRepository extends NoSQLRepository<Person, Long> {
 
     List<Person> findByName(String name);
 

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryLiteGraphTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryLiteGraphTest.java
@@ -16,7 +16,7 @@ package org.eclipse.jnosql.lite.mapping.entities;
 
 
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
 import org.assertj.core.api.Assertions;
 import org.eclipse.jnosql.mapping.graph.GraphTemplate;
 import org.eclipse.jnosql.mapping.graph.VertexTraversal;
@@ -34,7 +34,10 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class PersonCrudRepositoryLiteGraphTest {
@@ -96,13 +99,6 @@ public class PersonCrudRepositoryLiteGraphTest {
     }
 
     @Test
-    void shouldDeleteAllEntities() {
-        repository.deleteAll();
-
-        verify(template).deleteAll(eq(Person.class));
-    }
-
-    @Test
     void shouldInsert(){
         repository.insert(new Person());
         verify(template).insert(any(Person.class));
@@ -140,7 +136,7 @@ public class PersonCrudRepositoryLiteGraphTest {
     void shouldCountEntities() {
         when(template.count(eq(Person.class))).thenReturn(5L);
 
-        repository.count();
+        repository.countBy();
 
         verify(template).count(eq(Person.class));
     }
@@ -163,8 +159,8 @@ public class PersonCrudRepositoryLiteGraphTest {
     }
 
     @Test
-    void shouldFindAllEntitiesWithPageable() {
-        Pageable pageable = Pageable.ofPage(1);
+    void shouldFindAllEntitiesWithPageRequest() {
+        PageRequest pageable = PageRequest.ofPage(1);
 
         VertexTraversal traversalVertex = Mockito.mock(VertexTraversal.class);
 

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryLiteGraphTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonCrudRepositoryLiteGraphTest.java
@@ -160,7 +160,7 @@ public class PersonCrudRepositoryLiteGraphTest {
 
     @Test
     void shouldFindAllEntitiesWithPageRequest() {
-        PageRequest pageable = PageRequest.ofPage(1);
+        PageRequest pageRequest = PageRequest.ofPage(1);
 
         VertexTraversal traversalVertex = Mockito.mock(VertexTraversal.class);
 
@@ -171,7 +171,7 @@ public class PersonCrudRepositoryLiteGraphTest {
         when(traversalVertex.result()).thenReturn(Stream.of(new Person()));
 
 
-        Page<Person> page = repository.findAll(pageable);
+        Page<Person> page = repository.findAll(pageRequest);
 
         verify(template).traversalVertex();
         Assertions.assertThat(page).isNotNull().isNotEmpty().hasSize(1);

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryLiteGraphTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryLiteGraphTest.java
@@ -146,7 +146,7 @@ public class PersonRepositoryLiteGraphTest {
 
     @Test
     void shouldFindAllEntitiesWithPageRequest() {
-        PageRequest pageable = PageRequest.ofPage(1);
+        PageRequest pageRequest = PageRequest.ofPage(1);
 
         VertexTraversal traversalVertex = Mockito.mock(VertexTraversal.class);
 
@@ -157,7 +157,7 @@ public class PersonRepositoryLiteGraphTest {
         when(traversalVertex.result()).thenReturn(Stream.of(new Person()));
 
 
-        Page<Person> page = repository.findAll(pageable);
+        Page<Person> page = repository.findAll(pageRequest);
 
         verify(template).traversalVertex();
         Assertions.assertThat(page).isNotNull().isNotEmpty().hasSize(1);

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryLiteGraphTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryLiteGraphTest.java
@@ -16,7 +16,7 @@ package org.eclipse.jnosql.lite.mapping.entities;
 
 
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.assertj.core.api.Assertions;
 import org.eclipse.jnosql.mapping.graph.GraphTemplate;
@@ -100,13 +100,6 @@ public class PersonRepositoryLiteGraphTest {
     }
 
     @Test
-    void shouldDeleteAllEntities() {
-        repository.deleteAll();
-
-        verify(template).deleteAll(eq(Person.class));
-    }
-
-    @Test
     void shouldFindById() {
         Long id = 123L;
         when(template.find(eq(Person.class), eq(id))).thenReturn(java.util.Optional.of(new Person()));
@@ -120,7 +113,7 @@ public class PersonRepositoryLiteGraphTest {
     void shouldCountEntities() {
         when(template.count(eq(Person.class))).thenReturn(5L);
 
-        repository.count();
+        repository.countBy();
 
         verify(template).count(eq(Person.class));
     }
@@ -143,8 +136,8 @@ public class PersonRepositoryLiteGraphTest {
     }
 
     @Test
-    void shouldFindAllEntitiesWithPageable() {
-        Pageable pageable = Pageable.ofPage(1);
+    void shouldFindAllEntitiesWithPageRequest() {
+        PageRequest pageable = PageRequest.ofPage(1);
 
         VertexTraversal traversalVertex = Mockito.mock(VertexTraversal.class);
 

--- a/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryLiteGraphTest.java
+++ b/jnosql-lite/mapping-lite-graph-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepositoryLiteGraphTest.java
@@ -17,7 +17,6 @@ package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.assertj.core.api.Assertions;
 import org.eclipse.jnosql.mapping.graph.GraphTemplate;
 import org.eclipse.jnosql.mapping.graph.VertexTraversal;
@@ -38,7 +37,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class PersonRepositoryLiteGraphTest {
@@ -97,6 +99,13 @@ public class PersonRepositoryLiteGraphTest {
         repository.deleteByIdIn(List.of(1L, 2L, 3L));
 
         verify(template, times(3)).delete(anyLong());
+    }
+
+    @Test
+    void shouldDeleteAllEntities() {
+        repository.deleteAll();
+
+        verify(template).deleteAll(eq(Person.class));
     }
 
     @Test

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -17,7 +17,6 @@ package org.eclipse.jnosql.lite.mapping.entities;
 
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
-import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Param;
@@ -25,11 +24,12 @@ import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
+import org.eclipse.jnosql.mapping.NoSQLRepository;
 
 import java.util.List;
 
 @Repository
-public interface PersonRepository extends BasicRepository<Person, Long> {
+public interface PersonRepository extends NoSQLRepository<Person, Long> {
 
     List<Person> findByName(String name);
 

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/PersonRepository.java
@@ -16,10 +16,10 @@ package org.eclipse.jnosql.lite.mapping.entities;
 
 
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
-import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
@@ -29,13 +29,13 @@ import jakarta.data.repository.Update;
 import java.util.List;
 
 @Repository
-public interface PersonRepository extends PageableRepository<Person, Long> {
+public interface PersonRepository extends BasicRepository<Person, Long> {
 
     List<Person> findByName(String name);
 
     List<Person> findByNameOrderbyId(String name);
 
-    Page<Person> findByName(String name, Pageable pageable);
+    Page<Person> findByName(String name, PageRequest<Person> pageRequest);
 
     @Query("select * from Person where name = @name")
     List<Person> query(@Param("name") String name);

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserRepository.java
@@ -14,13 +14,13 @@
  */
 package org.eclipse.jnosql.lite.mapping.entities;
 
-import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Repository;
+import org.eclipse.jnosql.mapping.NoSQLRepository;
 
 import java.util.List;
 
 @Repository
-public interface UserRepository extends CrudRepository<User, String> {
+public interface UserRepository extends NoSQLRepository<User, String> {
 
     List<User> findByName(String name);
 }

--- a/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserRepository.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/main/java/org/eclipse/jnosql/lite/mapping/entities/UserRepository.java
@@ -14,13 +14,13 @@
  */
 package org.eclipse.jnosql.lite.mapping.entities;
 
-import jakarta.data.repository.PageableRepository;
+import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Repository;
 
 import java.util.List;
 
 @Repository
-public interface UserRepository extends PageableRepository<User, String> {
+public interface UserRepository extends CrudRepository<User, String> {
 
     List<User> findByName(String name);
 }

--- a/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepositoryLiteKeyValueTest.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserCrudRepositoryLiteKeyValueTest.java
@@ -113,7 +113,7 @@ public class UserCrudRepositoryLiteKeyValueTest {
 
     @Test
     void shouldThrowUnsupportedOperationExceptionOnCount() {
-        assertThrows(UnsupportedOperationException.class, () -> userRepository.count());
+        assertThrows(UnsupportedOperationException.class, () -> userRepository.countBy());
     }
 
     @Test

--- a/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserRepositoryLiteKeyValueTest.java
+++ b/jnosql-lite/mapping-lite-key-value-test/src/test/java/org/eclipse/jnosql/lite/mapping/entities/UserRepositoryLiteKeyValueTest.java
@@ -141,7 +141,7 @@ public class UserRepositoryLiteKeyValueTest {
 
     @Test
     void shouldThrowUnsupportedOperationExceptionOnCount() {
-        assertThrows(UnsupportedOperationException.class, () -> userRepository.count());
+        assertThrows(UnsupportedOperationException.class, () -> userRepository.countBy());
     }
 
     @Test

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
@@ -90,7 +90,7 @@ class MethodMetadata {
 
     public String getParametersSignature() {
         return parameters.stream().map(Parameter::parameterName)
-                .collect(joining(", "));
+                .collect(joining(", \n" + " ".repeat(30)));
     }
 
     void update(Function<MethodMetadata, MethodGenerator> methodGeneratorFactory) {

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
@@ -43,6 +43,7 @@ class MethodMetadata {
     private static final Predicate<Parameter> IS_SPECIAL_PARAM = p -> p.type().getQualifiedName().toString().equals(Limit.class.getName()) ||
             p.type().getQualifiedName().toString().equals(PageRequest.class.getName()) ||
             p.type().getQualifiedName().toString().equals(Sort.class.getName());
+    public static final int DEFAULT_NEWLINE_SPACING = 30;
     private final String methodName;
 
     private final TypeElement returnElement;
@@ -90,7 +91,7 @@ class MethodMetadata {
 
     public String getParametersSignature() {
         return parameters.stream().map(Parameter::parameterName)
-                .collect(joining(", \n" + " ".repeat(30)));
+                .collect(joining(", \n" + " ".repeat(DEFAULT_NEWLINE_SPACING)));
     }
 
     void update(Function<MethodMetadata, MethodGenerator> methodGeneratorFactory) {

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
@@ -16,7 +16,7 @@ package org.eclipse.jnosql.lite.mapping.repository;
 
 import jakarta.data.Limit;
 import jakarta.data.Sort;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Query;
@@ -41,7 +41,7 @@ import static java.util.stream.Collectors.joining;
 class MethodMetadata {
 
     private static final Predicate<Parameter> IS_SPECIAL_PARAM = p -> p.type().getQualifiedName().toString().equals(Limit.class.getName()) ||
-            p.type().getQualifiedName().toString().equals(Pageable.class.getName()) ||
+            p.type().getQualifiedName().toString().equals(PageRequest.class.getName()) ||
             p.type().getQualifiedName().toString().equals(Sort.class.getName());
     private final String methodName;
 
@@ -90,7 +90,7 @@ class MethodMetadata {
 
     public String getParametersSignature() {
         return parameters.stream().map(Parameter::parameterName)
-                .collect(joining(","));
+                .collect(joining(",\n"));
     }
 
     void update(Function<MethodMetadata, MethodGenerator> methodGeneratorFactory) {
@@ -147,10 +147,10 @@ class MethodMetadata {
         return entityType;
     }
 
-    public Optional<Parameter> findPageable(){
+    public Optional<Parameter> findPageRequest(){
         for (Parameter parameter : this.parameters) {
             TypeElement element = parameter.type();
-            if("jakarta.data.page.Pageable".equals(element.getQualifiedName().toString())){
+            if(PageRequest.class.getName().equals(element.getQualifiedName().toString())){
                 return Optional.of(parameter);
             }
         }

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodMetadata.java
@@ -90,7 +90,7 @@ class MethodMetadata {
 
     public String getParametersSignature() {
         return parameters.stream().map(Parameter::parameterName)
-                .collect(joining(",\n"));
+                .collect(joining(", "));
     }
 
     void update(Function<MethodMetadata, MethodGenerator> methodGeneratorFactory) {

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodQueryRepositoryReturnType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodQueryRepositoryReturnType.java
@@ -85,7 +85,7 @@ enum MethodQueryRepositoryReturnType implements Function<MethodMetadata, List<St
         public List<String> apply(MethodMetadata metadata) {
             List<String> lines = new ArrayList<>();
             lines.add("Stream<" + getEntity(metadata) + "> entities = this.template.select(query)");
-            Parameter pageable = metadata.findPageable()
+            Parameter pageable = metadata.findPageRequest()
                     .orElseThrow(() -> new ValidationException("The method " + metadata.getMethodName() + " from " +
                             metadata.getParametersSignature() + " does not have a Pageable parameter in a pagination method"));
 

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodQueryRepositoryReturnType.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/MethodQueryRepositoryReturnType.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.jnosql.lite.mapping.repository;
 
+import jakarta.data.page.Page;
 import org.eclipse.jnosql.lite.mapping.ValidationException;
 
 import java.util.ArrayList;
@@ -85,12 +86,12 @@ enum MethodQueryRepositoryReturnType implements Function<MethodMetadata, List<St
         public List<String> apply(MethodMetadata metadata) {
             List<String> lines = new ArrayList<>();
             lines.add("Stream<" + getEntity(metadata) + "> entities = this.template.select(query)");
-            Parameter pageable = metadata.findPageRequest()
+            Parameter pageRequest = metadata.findPageRequest()
                     .orElseThrow(() -> new ValidationException("The method " + metadata.getMethodName() + " from " +
                             metadata.getParametersSignature() + " does not have a Pageable parameter in a pagination method"));
 
-            lines.add("jakarta.data.page.Page<" + getEntity(metadata) + "> result = \n      " +
-                    "org.eclipse.jnosql.mapping.core.NoSQLPage.of(entities.toList(), " + pageable.name() + ")");
+            lines.add(Page.class.getName() + "<" + getEntity(metadata) + "> result = \n      " +
+                    "org.eclipse.jnosql.mapping.core.NoSQLPage.of(entities.toList(), " + pageRequest.name() + ")");
             return lines;
         }
     };

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryElement.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryElement.java
@@ -15,8 +15,8 @@
  */
 package org.eclipse.jnosql.lite.mapping.repository;
 
+import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.CrudRepository;
-import jakarta.data.repository.PageableRepository;
 import org.eclipse.jnosql.lite.mapping.ValidationException;
 import org.eclipse.jnosql.mapping.DatabaseType;
 
@@ -118,7 +118,7 @@ class RepositoryElement {
             }
         }
         throw new ValidationException("The interface %s must extends %s"
-                .formatted(element.toString(), String.join(" or ", PageableRepository.class.getName(), CrudRepository.class.getName())));
+                .formatted(element.toString(), String.join(" or ", BasicRepository.class.getName(), CrudRepository.class.getName())));
     }
 
 }

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryMetadata.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryMetadata.java
@@ -59,7 +59,8 @@ abstract class RepositoryMetadata implements Function<MethodMetadata, MethodGene
         return this.element.getMethods();
     }
 
-    protected RepositoryElement getElement() {
+    public RepositoryElement getElement() {
         return element;
     }
+
 }

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryUtil.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryUtil.java
@@ -16,6 +16,7 @@ package org.eclipse.jnosql.lite.mapping.repository;
 
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.CrudRepository;
+import org.eclipse.jnosql.mapping.NoSQLRepository;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;
@@ -29,9 +30,10 @@ import java.util.stream.Collectors;
 
 final class RepositoryUtil {
 
-    static final Predicate<String> IS_BASIC_REPOSITORY = q -> BasicRepository.class.getName().equals(q);
+    static final Predicate<String> IS_NOSQL_REPOSITORY = q -> NoSQLRepository.class.getName().equals(q);
     static final Predicate<String> IS_CRUD_REPOSITORY = q -> CrudRepository.class.getName().equals(q);
-    static final Predicate<String> IS_JAKARTA_DATA_REPOSITORY = IS_BASIC_REPOSITORY.or(IS_CRUD_REPOSITORY);
+    static final Predicate<String> IS_BASIC_REPOSITORY = q -> BasicRepository.class.getName().equals(q);
+    static final Predicate<String> IS_JAKARTA_DATA_REPOSITORY = IS_NOSQL_REPOSITORY.or(IS_CRUD_REPOSITORY).or(IS_BASIC_REPOSITORY);
 
     private RepositoryUtil() {
     }
@@ -54,5 +56,13 @@ final class RepositoryUtil {
                     .collect(Collectors.toList());
         }
         return Collections.emptyList();
+    }
+
+    static boolean isNoSQLRepository(List<? extends TypeMirror> interfaces, ProcessingEnvironment processingEnv) {
+        return interfaces.stream()
+                .map(processingEnv.getTypeUtils()::asElement)
+                .map(TypeElement.class::cast)
+                .map(t -> t.getQualifiedName().toString())
+                .anyMatch(IS_NOSQL_REPOSITORY);
     }
 }

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryUtil.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryUtil.java
@@ -14,8 +14,8 @@
  */
 package org.eclipse.jnosql.lite.mapping.repository;
 
+import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.CrudRepository;
-import jakarta.data.repository.PageableRepository;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;
@@ -29,9 +29,9 @@ import java.util.stream.Collectors;
 
 final class RepositoryUtil {
 
-    static final Predicate<String> IS_PAGEABLE_REPOSITORY = q -> PageableRepository.class.getName().equals(q);
+    static final Predicate<String> IS_BASIC_REPOSITORY = q -> BasicRepository.class.getName().equals(q);
     static final Predicate<String> IS_CRUD_REPOSITORY = q -> CrudRepository.class.getName().equals(q);
-    static final Predicate<String> IS_JAKARTA_DATA_REPOSITORY = IS_PAGEABLE_REPOSITORY.or(IS_CRUD_REPOSITORY);
+    static final Predicate<String> IS_JAKARTA_DATA_REPOSITORY = IS_BASIC_REPOSITORY.or(IS_CRUD_REPOSITORY);
 
     private RepositoryUtil() {
     }

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_column.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_column.mustache
@@ -14,8 +14,9 @@
  */
 package {{package}};
 
+import jakarta.data.Sort;
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
 import org.eclipse.jnosql.communication.column.ColumnQuery;
 
 import org.eclipse.jnosql.lite.mapping.metadata.LiteEntitiesMetadata;
@@ -121,10 +122,6 @@ public class {{className}} implements {{repository}} {
         entities.forEach(this::delete);
     }
 
-    @Override
-    public void deleteAll() {
-        getTemplate().deleteAll(getEntityClass());
-    }
 
     @Override
     public Optional<{{entityType}}> findById({{keyType}} id) {
@@ -141,7 +138,7 @@ public class {{className}} implements {{repository}} {
     }
 
     @Override
-    public long count() {
+    public long countBy() {
         return getTemplate().count(getEntityClass());
     }
 
@@ -156,14 +153,15 @@ public class {{className}} implements {{repository}} {
         return getTemplate().select(query);
     }
 
-    public Page<{{entityType}}> findAll(Pageable pageable) {
-        Objects.requireNonNull(pageable, "pageable is required");
+    public Page<{{entityType}}> findAll(PageRequest<{{entityType}}> pageRequest) {
+        Objects.requireNonNull(pageRequest, "pageRequest is required");
         EntityMetadata metadata = getEntityMetadata();
-        ColumnQuery query = new MappingColumnQuery(pageable.sorts(),
-        pageable.size(), NoSQLPage.skip(pageable), null ,metadata.name());
+        List<Sort<?>> sorts = pageRequest.sorts().stream().collect(toList());
+        ColumnQuery query = new MappingColumnQuery(sorts,
+        pageRequest.size(), NoSQLPage.skip(pageRequest), null ,metadata.name());
 
         List<{{entityType}}> entities = getTemplate().<{{entityType}}>select(query).toList();
-            return NoSQLPage.of(entities, pageable);
+            return NoSQLPage.of(entities, pageRequest);
     }
 
     public <S extends {{entityType}}> S insert(S entity) {

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_column.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_column.mustache
@@ -122,6 +122,12 @@ public class {{className}} implements {{repository}} {
         entities.forEach(this::delete);
     }
 
+    {{#element.isNoSQLRepository}}
+    @Override
+    public void deleteAll() {
+        getTemplate().deleteAll(getEntityClass());
+    }
+    {{/element.isNoSQLRepository}}
 
     @Override
     public Optional<{{entityType}}> findById({{keyType}} id) {

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_document.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_document.mustache
@@ -120,6 +120,12 @@ public class {{className}} implements {{repository}} {
         entities.forEach(this::delete);
     }
 
+    {{#element.isNoSQLRepository}}
+    @Override
+    public void deleteAll() {
+        getTemplate().deleteAll(getEntityClass());
+    }
+    {{/element.isNoSQLRepository}}
 
     @Override
     public Optional<{{entityType}}> findById({{keyType}} id) {

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_document.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_document.mustache
@@ -14,8 +14,9 @@
  */
 package {{package}};
 
+import jakarta.data.Sort;
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
 import org.eclipse.jnosql.communication.document.DocumentQuery;
 import org.eclipse.jnosql.lite.mapping.metadata.LiteEntitiesMetadata;
 import org.eclipse.jnosql.mapping.core.NoSQLPage;
@@ -119,10 +120,6 @@ public class {{className}} implements {{repository}} {
         entities.forEach(this::delete);
     }
 
-    @Override
-    public void deleteAll() {
-       getTemplate().deleteAll(getEntityClass());
-    }
 
     @Override
     public Optional<{{entityType}}> findById({{keyType}} id) {
@@ -138,7 +135,7 @@ public class {{className}} implements {{repository}} {
     }
 
     @Override
-    public long count() {
+    public long countBy() {
         return getTemplate().count(getEntityClass());
     }
 
@@ -153,14 +150,15 @@ public class {{className}} implements {{repository}} {
         return getTemplate().select(query);
     }
 
-    public Page<{{entityType}}> findAll(Pageable pageable) {
-        Objects.requireNonNull(pageable, "pageable is required");
+    public Page<{{entityType}}> findAll(PageRequest<{{entityType}}> pageRequest) {
+        Objects.requireNonNull(pageRequest, "pageRequest is required");
         EntityMetadata metadata = getEntityMetadata();
-        DocumentQuery query = new MappingDocumentQuery(pageable.sorts(),
-        pageable.size(), NoSQLPage.skip(pageable), null ,metadata.name());
+        List<Sort<?>> sorts = pageRequest.sorts().stream().collect(toList());
+        DocumentQuery query = new MappingDocumentQuery(sorts,
+        pageRequest.size(), NoSQLPage.skip(pageRequest), null ,metadata.name());
 
         List<{{entityType}}> entities = getTemplate().<{{entityType}}>select(query).toList();
-                return NoSQLPage.of(entities, pageable);
+                return NoSQLPage.of(entities, pageRequest);
     }
 
     public <S extends {{entityType}}> S insert(S entity) {

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_graph.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_graph.mustache
@@ -115,7 +115,14 @@ public class {{className}} implements {{repository}} {
         entities.forEach(this::delete);
     }
 
+    {{#element.isNoSQLRepository}}
     @Override
+    public void deleteAll() {
+        getTemplate().deleteAll(getEntityClass());
+    }
+    {{/element.isNoSQLRepository}}
+
+        @Override
     public Optional<{{entityType}}> findById({{keyType}} id) {
         requireNonNull(id, "id is required");
         return getTemplate().find(getEntityClass(), id);

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_graph.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_graph.mustache
@@ -15,7 +15,7 @@
 package {{package}};
 
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
 import org.eclipse.jnosql.lite.mapping.metadata.LiteEntitiesMetadata;
 import org.eclipse.jnosql.mapping.core.NoSQLPage;
 import org.eclipse.jnosql.mapping.graph.GraphTemplate;
@@ -116,11 +116,6 @@ public class {{className}} implements {{repository}} {
     }
 
     @Override
-    public void deleteAll() {
-       getTemplate().deleteAll(getEntityClass());
-    }
-
-    @Override
     public Optional<{{entityType}}> findById({{keyType}} id) {
         requireNonNull(id, "id is required");
         return getTemplate().find(getEntityClass(), id);
@@ -134,7 +129,7 @@ public class {{className}} implements {{repository}} {
     }
 
     @Override
-    public long count() {
+    public long countBy() {
         return getTemplate().count(getEntityClass());
     }
 
@@ -148,17 +143,17 @@ public class {{className}} implements {{repository}} {
         return getTemplate().findAll(getEntityClass());
     }
 
-    public Page<{{entityType}}> findAll(Pageable pageable) {
-        Objects.requireNonNull(pageable, "pageable is required");
+    public Page<{{entityType}}> findAll(PageRequest<{{entityType}}> pageRequest) {
+        Objects.requireNonNull(pageRequest, "pageRequest is required");
         EntityMetadata metadata = getEntityMetadata();
 
         List<{{entityType}}> entities = getTemplate().traversalVertex()
             .hasLabel(metadata.type())
-            .skip(NoSQLPage.skip(pageable))
-            .limit(pageable.size())
+            .skip(NoSQLPage.skip(pageRequest))
+            .limit(pageRequest.size())
              .<{{entityType}}>result()
             .toList();
-        return NoSQLPage.of(entities, pageable);
+        return NoSQLPage.of(entities, pageRequest);
     }
 
     public <S extends {{entityType}}> S insert(S entity) {

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_key-value.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_key-value.mustache
@@ -125,6 +125,13 @@ public class {{className}} implements {{repository}} {
          throw new UnsupportedOperationException("Key-Value repository does not support findAll method");
     }
 
+    {{#element.isNoSQLRepository}}
+    @Override
+    public void deleteAll() {
+        throw new UnsupportedOperationException("Key-Value repository does not support deleteAll method");
+    }
+    {{/element.isNoSQLRepository}}
+
     @Override
     public void deleteAll(Iterable<? extends {{entityType}}> entities) {
         Objects.requireNonNull(entities, "entities is required");

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_key-value.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_key-value.mustache
@@ -20,7 +20,7 @@ import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
 import org.eclipse.jnosql.mapping.metadata.FieldMetadata;
 
 import jakarta.data.page.Page;
-import jakarta.data.page.Pageable;
+import jakarta.data.page.PageRequest;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Inject;
@@ -112,22 +112,17 @@ public class {{className}} implements {{repository}} {
     }
 
     @Override
-    public long count() {
+    public long countBy() {
         throw new UnsupportedOperationException("Key-Value repository does not support count method");
     }
 
-    public Page<{{entityType}}> findAll(Pageable pageable) {
+    public Page<{{entityType}}> findAll(PageRequest<{{entityType}}> pageRequest) {
         throw new UnsupportedOperationException("Key-Value repository does not support findAll method");
     }
 
     @Override
     public Stream<{{entityType}}> findAll() {
          throw new UnsupportedOperationException("Key-Value repository does not support findAll method");
-    }
-
-    @Override
-    public void deleteAll() {
-         throw new UnsupportedOperationException("Key-Value repository does not support deleteAll method");
     }
 
     @Override


### PR DESCRIPTION
## Changes

- Bump up the actions that use Node.js 20 runtime (For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/):
  - actions/checkout@v3 to v4;
  - actions/setup-java@v3 to v4;

- Upgrade the API to Jakarta Data 1.0.0-M3